### PR TITLE
fix(hash): added support for hyprland 0.52+'s new hash format

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -166,7 +166,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
   const std::string HASH = __hyprland_api_get_hash();
 
-  if (HASH != GIT_COMMIT_HASH) {
+  if (HASH.find(GIT_COMMIT_HASH) != 0) {
     HyprlandAPI::addNotification(
         PHANDLE,
         "[Hyprfoci] Failure in initialization: Version mismatch (headers ver "


### PR DESCRIPTION
## Describe your changes

Hyprland 0.52 changed its hash format to include dependency versions. I added a simple fix to check whether the git commit hash is contained within hyprland's runtime hash.
example hashes:
0.51.1:
GIT_COMMIT_HASH=71a1216abcc7031776630a6d88f105605c4dc1c9
HASH=71a1216abcc7031776630a6d88f105605c4dc1c9
0.52.2:
GIT_COMMIT_HASH=386376400119dd46a767c9f8c8791fd22c7b6e61
HASH=386376400119dd46a767c9f8c8791fd22c7b6e61_aq_0.10_hu_0.11_hg_0.4_hc_0.1_hlg_0.6


## Issue ticket and link

