### PR TITLE
fix(windowrule): rewritten for new hyprland windowrules

### DIFF
--- a/CDotDecoration.cpp
+++ b/CDotDecoration.cpp
@@ -2,8 +2,8 @@
 #include "globals.hpp"
 
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/desktop/Window.hpp>
-#include <hyprland/src/desktop/WindowRule.hpp>
+#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/desktop/rule/windowRule/WindowRule.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/render/decorations/IHyprWindowDecoration.hpp>
@@ -16,14 +16,6 @@
 CDotDecoration::CDotDecoration(PHLWINDOW pWindow)
     : IHyprWindowDecoration(pWindow) {
   m_pWindow = pWindow;
-  m_pEnabled = true;
-
-  for (const auto &r : m_pWindow->m_matchedRules) {
-    if (r->m_ruleType == CWindowRule::RULE_PLUGIN &&
-        r->m_rule == "plugin:hyprfoci:enabled 0") {
-      m_pEnabled = false;
-    }
-  }
 
   if (g_pTextures["both.png"]) {
     m_pTexture = g_pTextures["both.png"];
@@ -98,13 +90,11 @@ SDecorationPositioningInfo CDotDecoration::getPositioningInfo() {
 }
 
 void CDotDecoration::draw(PHLMONITOR pMonitor, float const &a) {
-  if (!m_pEnabled)
-    return;
   if (!validMapped(m_pWindow))
     return;
 
   const auto PWINDOW = m_pWindow.lock();
-  if (!PWINDOW->m_windowData.decorate.valueOrDefault())
+  if (!PWINDOW->m_ruleApplicator->decorate().valueOrDefault())
     return;
 
   CBox squareBox = getSquareBox();

--- a/CDotDecoration.cpp
+++ b/CDotDecoration.cpp
@@ -12,6 +12,7 @@
 #include <hyprlang.hpp>
 #include <hyprutils/memory/UniquePtr.hpp>
 #include <string>
+#include <hyprland/src/event/EventBus.hpp>
 
 CDotDecoration::CDotDecoration(PHLWINDOW pWindow)
     : IHyprWindowDecoration(pWindow) {
@@ -19,11 +20,6 @@ CDotDecoration::CDotDecoration(PHLWINDOW pWindow)
 
   if (g_pTextures["both.png"]) {
     m_pTexture = g_pTextures["both.png"];
-    // m_pKeypressCallback = HyprlandAPI::registerCallbackDynamic(
-    //     PHANDLE, "keyPress",
-    //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
-    //       onKeypress(info, data);
-    //     });/usr/include/hyprland/src/devices/IKeyboard.hpp
     m_pKeypressCallback = Event::bus()->m_events.input.keyboard.key.listen(
         [&](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
             onKeypress(event, info);
@@ -36,32 +32,12 @@ CDotDecoration::CDotDecoration(PHLWINDOW pWindow)
 }
 
 void CDotDecoration::onKeypress(IKeyboard::SKeyEvent event, Event::SCallbackInfo &info) {
-  // auto const keyEvent =
-  //     std::any_cast<std::unordered_map<std::string, std::any>>(data);
-  // auto const event = std::any_cast<IKeyboard::SKeyEvent>(keyEvent.at("event"));
 
   auto const hand = getHandForKeyEvent(event);
-    // HyprlandAPI::addNotification(
-    //     PHANDLE,
-    //     hand,
-    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
-    // HyprlandAPI::addNotification(
-    //     PHANDLE,
-    //     std::to_string(event.state),
-    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
-    // HyprlandAPI::addNotification(
-    //     PHANDLE,
-    //     std::to_string(WL_KEYBOARD_KEY_STATE_PRESSED),
-    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
 
   std::string textureName;
   if (event.state == WL_KEYBOARD_KEY_STATE_PRESSED) {
     textureName = hand;
-    // HyprlandAPI::addNotification(
-    //     PHANDLE,
-    //     "should be triggering",
-    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
-
   } else {
     textureName = "both.png";
   }
@@ -73,15 +49,6 @@ void CDotDecoration::onKeypress(IKeyboard::SKeyEvent event, Event::SCallbackInfo
 
 std::string CDotDecoration::getHandForKeyEvent(IKeyboard::SKeyEvent event) {
   uint32_t keycode = event.keycode;
-
-    HyprlandAPI::addNotification(
-        PHANDLE,
-        std::to_string(keycode),
-        CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
-//HyprlandAPI::addNotification(PHANDLE, 
-//    "keycode: " + std::to_string(event.keycode) + " time: " + std::to_string(event.timeMs),
-    CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
-
 
   // Left hand keys on a standard QWERTY keyboard
   const std::vector<uint32_t> leftHandKeys = {// Left side of number row

--- a/CDotDecoration.cpp
+++ b/CDotDecoration.cpp
@@ -19,10 +19,14 @@ CDotDecoration::CDotDecoration(PHLWINDOW pWindow)
 
   if (g_pTextures["both.png"]) {
     m_pTexture = g_pTextures["both.png"];
-    m_pKeypressCallback = HyprlandAPI::registerCallbackDynamic(
-        PHANDLE, "keyPress",
-        [&](void *self, SCallbackInfo &info, std::any data) {
-          onKeypress(info, data);
+    // m_pKeypressCallback = HyprlandAPI::registerCallbackDynamic(
+    //     PHANDLE, "keyPress",
+    //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
+    //       onKeypress(info, data);
+    //     });/usr/include/hyprland/src/devices/IKeyboard.hpp
+    m_pKeypressCallback = Event::bus()->m_events.input.keyboard.key.listen(
+        [&](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
+            onKeypress(event, info);
         });
   } else if (g_pTexture) {
     m_pTexture = g_pTexture;
@@ -31,15 +35,33 @@ CDotDecoration::CDotDecoration(PHLWINDOW pWindow)
   const auto PMONITOR = pWindow->m_monitor.lock();
 }
 
-void CDotDecoration::onKeypress(SCallbackInfo &info, std::any data) {
-  auto const keyEvent =
-      std::any_cast<std::unordered_map<std::string, std::any>>(data);
-  auto const event = std::any_cast<IKeyboard::SKeyEvent>(keyEvent.at("event"));
+void CDotDecoration::onKeypress(IKeyboard::SKeyEvent event, Event::SCallbackInfo &info) {
+  // auto const keyEvent =
+  //     std::any_cast<std::unordered_map<std::string, std::any>>(data);
+  // auto const event = std::any_cast<IKeyboard::SKeyEvent>(keyEvent.at("event"));
+
   auto const hand = getHandForKeyEvent(event);
+    // HyprlandAPI::addNotification(
+    //     PHANDLE,
+    //     hand,
+    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+    // HyprlandAPI::addNotification(
+    //     PHANDLE,
+    //     std::to_string(event.state),
+    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+    // HyprlandAPI::addNotification(
+    //     PHANDLE,
+    //     std::to_string(WL_KEYBOARD_KEY_STATE_PRESSED),
+    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
 
   std::string textureName;
   if (event.state == WL_KEYBOARD_KEY_STATE_PRESSED) {
     textureName = hand;
+    // HyprlandAPI::addNotification(
+    //     PHANDLE,
+    //     "should be triggering",
+    //     CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+
   } else {
     textureName = "both.png";
   }
@@ -51,6 +73,15 @@ void CDotDecoration::onKeypress(SCallbackInfo &info, std::any data) {
 
 std::string CDotDecoration::getHandForKeyEvent(IKeyboard::SKeyEvent event) {
   uint32_t keycode = event.keycode;
+
+    HyprlandAPI::addNotification(
+        PHANDLE,
+        std::to_string(keycode),
+        CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+//HyprlandAPI::addNotification(PHANDLE, 
+//    "keycode: " + std::to_string(event.keycode) + " time: " + std::to_string(event.timeMs),
+    CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+
 
   // Left hand keys on a standard QWERTY keyboard
   const std::vector<uint32_t> leftHandKeys = {// Left side of number row

--- a/CDotDecoration.hpp
+++ b/CDotDecoration.hpp
@@ -25,5 +25,4 @@ private:
   SP<HOOK_CALLBACK_FN> m_pKeypressCallback;
   PHLWINDOWREF m_pWindow;
   SP<CTexture> m_pTexture;
-  bool m_pEnabled;
 };

--- a/CDotDecoration.hpp
+++ b/CDotDecoration.hpp
@@ -2,6 +2,7 @@
 #include <hyprland/src/devices/Keyboard.hpp>
 #include <hyprland/src/render/Texture.hpp>
 #include <hyprland/src/render/decorations/IHyprWindowDecoration.hpp>
+#include <hyprland/src/event/EventBus.hpp>
 
 class CDotDecoration : public IHyprWindowDecoration {
 public:
@@ -18,11 +19,11 @@ public:
   virtual CBox getSquareBox();
   virtual void onPositioningReply(const SDecorationPositioningReply &reply);
   PHLWINDOW getOwner();
-  virtual void onKeypress(SCallbackInfo &info, std::any data);
+  virtual void onKeypress(IKeyboard::SKeyEvent event, Event::SCallbackInfo &info);
   virtual std::string getHandForKeyEvent(IKeyboard::SKeyEvent event);
 
 private:
-  SP<HOOK_CALLBACK_FN> m_pKeypressCallback;
+  CHyprSignalListener m_pKeypressCallback;
   PHLWINDOWREF m_pWindow;
   SP<CTexture> m_pTexture;
 };

--- a/CDotDecoration.hpp
+++ b/CDotDecoration.hpp
@@ -3,6 +3,7 @@
 #include <hyprland/src/render/Texture.hpp>
 #include <hyprland/src/render/decorations/IHyprWindowDecoration.hpp>
 #include <hyprland/src/event/EventBus.hpp>
+#include <hyprutils/signal/Signal.hpp>
 
 class CDotDecoration : public IHyprWindowDecoration {
 public:
@@ -23,7 +24,7 @@ public:
   virtual std::string getHandForKeyEvent(IKeyboard::SKeyEvent event);
 
 private:
-  CHyprSignalListener m_pKeypressCallback;
+  Hyprutils::Signal::CHyprSignalListener m_pKeypressCallback;
   PHLWINDOWREF m_pWindow;
   SP<CTexture> m_pTexture;
 };

--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ plugin {
 
 		# Absolute path is needed (~ for home directory is fine)
 		img = /path/to/your/image.png
+        
+        # can also exclude specific windows!
+        exclude = kitty, firefox        
 	}
 }
-# can also disable/enable with windowrule!
-windowrule = plugin:hyprfoci:enabled 0, class:kitty
 ```
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -118,8 +118,8 @@ void initialLoad() {
   }
 }
 
-void onCloseWindow(void *self, std::any data) {
-  const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
+void onCloseWindow(PHLWINDOW PWINDOW) {
+  // const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
   auto square = current;
 
   if (current && current->getOwner() == PWINDOW) {
@@ -128,8 +128,8 @@ void onCloseWindow(void *self, std::any data) {
   }
 }
 
-void onActiveWindow(void *self, std::any data) {
-  const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
+void onActiveWindow(PHLWINDOW PWINDOW) {
+  // const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
 
   if (!isTextureLoaded)
     initialLoad();
@@ -163,7 +163,7 @@ void onActiveWindow(void *self, std::any data) {
   }
 }
 
-void onConfigReload(void *self, std::any data) {
+void onConfigReload() {
   const auto PWINDOW = Desktop::focusState()->window();
 
   if (current) {
@@ -214,22 +214,25 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
   HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfoci:imgs",
                               Hyprlang::STRING{"none"});
 
-  static auto P = HyprlandAPI::registerCallbackDynamic(
-      PHANDLE, "closeWindow",
-      [&](void *self, SCallbackInfo &info, std::any data) {
-        onCloseWindow(self, data);
-      });
+  // static auto P = HyprlandAPI::registerCallbackDynamic(
+  //     PHANDLE, "closeWindow",
+  //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
+  //       onCloseWindow(self, data);
+  //     });
+  //
+  // static auto P1 = HyprlandAPI::registerCallbackDynamic(
+  //     PHANDLE, "activeWindow",
+  //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
+  //       onActiveWindow(self, data);
+  //     });
+  // static auto P2 = HyprlandAPI::registerCallbackDynamic(
+  //     PHANDLE, "configReloaded",
+  //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
+  //       onConfigReload(self, data);
 
-  static auto P1 = HyprlandAPI::registerCallbackDynamic(
-      PHANDLE, "activeWindow",
-      [&](void *self, SCallbackInfo &info, std::any data) {
-        onActiveWindow(self, data);
-      });
-  static auto P2 = HyprlandAPI::registerCallbackDynamic(
-      PHANDLE, "configReloaded",
-      [&](void *self, SCallbackInfo &info, std::any data) {
-        onConfigReload(self, data);
-      });
+static auto P  = Event::bus()->m_events.window.close.listen([&](PHLWINDOW w) { onCloseWindow(w); });
+static auto P1 = Event::bus()->m_events.window.active.listen([&](PHLWINDOW w, Desktop::eFocusReason reason) { onActiveWindow(w); });
+static auto P2 = Event::bus()->m_events.config.reloaded.listen([&] { onConfigReload(); });
 
   // generate a deco for current window if exists
   for (auto &w : g_pCompositor->m_windows) {

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/helpers/MiscFunctions.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/view/Window.hpp>
 #include <hyprlang.hpp>
@@ -119,7 +120,6 @@ void initialLoad() {
 }
 
 void onCloseWindow(PHLWINDOW PWINDOW) {
-  // const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
   auto square = current;
 
   if (current && current->getOwner() == PWINDOW) {
@@ -129,7 +129,6 @@ void onCloseWindow(PHLWINDOW PWINDOW) {
 }
 
 void onActiveWindow(PHLWINDOW PWINDOW) {
-  // const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
 
   if (!isTextureLoaded)
     initialLoad();
@@ -213,22 +212,6 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                               Hyprlang::STRING{"none"});
   HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfoci:imgs",
                               Hyprlang::STRING{"none"});
-
-  // static auto P = HyprlandAPI::registerCallbackDynamic(
-  //     PHANDLE, "closeWindow",
-  //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
-  //       onCloseWindow(self, data);
-  //     });
-  //
-  // static auto P1 = HyprlandAPI::registerCallbackDynamic(
-  //     PHANDLE, "activeWindow",
-  //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
-  //       onActiveWindow(self, data);
-  //     });
-  // static auto P2 = HyprlandAPI::registerCallbackDynamic(
-  //     PHANDLE, "configReloaded",
-  //     [&](void *self, Event::SCallbackInfo &info, std::any data) {
-  //       onConfigReload(self, data);
 
 static auto P  = Event::bus()->m_events.window.close.listen([&](PHLWINDOW w) { onCloseWindow(w); });
 static auto P1 = Event::bus()->m_events.window.active.listen([&](PHLWINDOW w, Desktop::eFocusReason reason) { onActiveWindow(w); });


### PR DESCRIPTION
## Describe your changes
fixed for hyprland 0.53, and added "exclude" config variable to replace regressed "windowrule = plugin:hyprfoci:enabled 0"

## Issue ticket and link

